### PR TITLE
Update the script used to generate CSVs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /renv/
+.Rhistory
 .Rprofile
 .Rproj.user
+cache/*
 output/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /renv/
 .Rprofile
 .Rproj.user
+output/*

--- a/generate_CSVs.R
+++ b/generate_CSVs.R
@@ -24,6 +24,9 @@ library(xml2)
 library(data.table)
 library(stringdist)
 
+output_dir <- "output"
+dir.create(output_dir, showWarnings = FALSE)
+
 # read auxiliary classification
 src <- read_xml("./hilfsklassifikation.xml")
 
@@ -58,7 +61,7 @@ for (cat_num in seq_along(ids)) {
 
 
 hilfskategorien <- res[order(id)]
-# write.csv2(res[order(id)], row.names = FALSE, file = "hilfskategorien_sortiert_nach_id.csv", fileEncoding = "UTF-8")
+write.csv2(res[order(id)], row.names = FALSE, file = file.path(output_dir, "hilfskategorien_sortiert_nach_id.csv"), fileEncoding = "UTF-8")
 
 ###############################################
 ### Write data to excel file, listing all abgrenzungen
@@ -79,7 +82,7 @@ for (cat_num in seq_along(ids)) {
 }
 
 abgrenzungen <- res[order(kldb_id_default)]
-# write.csv2(res[order(kldb_id_default)], row.names = FALSE, file = "abgrenzungen_sortiert_nach_kldb.csv", fileEncoding = "UTF-8")
+write.csv2(res[order(kldb_id_default)], row.names = FALSE, file = file.path(output_dir, "abgrenzungen_sortiert_nach_kldb.csv"), fileEncoding = "UTF-8")
 
 ###############################################
 ### Write data to excel file, listing all Folgefragen
@@ -119,7 +122,7 @@ res <- res[order(id)]
 res[, laufindexFolge := 1:.N]
 
 folgefragen <- res[, list(laufindexFolge, id, questionNumber, typ, fragetextAktuellerBeruf, fragetextVergangenerBeruf, antwort.pos, antwort.text, antwort.kldb, antwort.isco, followUp)]
-# write.csv2(res[, list(laufindexFolge, id, questionNumber, typ, fragetextAktuellerBeruf, fragetextVergangenerBeruf, antwort.pos, antwort.text, antwort.kldb, antwort.isco, followUp)], row.names = FALSE, file = "folgefragen.csv", fileEncoding = "UTF-8")
+write.csv2(res[, list(laufindexFolge, id, questionNumber, typ, fragetextAktuellerBeruf, fragetextVergangenerBeruf, antwort.pos, antwort.text, antwort.kldb, antwort.isco, followUp)], row.names = FALSE, file = file.path(output_dir, "folgefragen.csv"), fileEncoding = "UTF-8")
 
 
 ##############################################
@@ -167,4 +170,4 @@ res <- rbind(
 res <- unique(res)
 
 map_kldb_to_auxcoid <- res
-# write.csv2(res, row.names = FALSE, file = "hilfskategorien_kldb_mit_id.csv", fileEncoding = "UTF-8")
+write.csv2(res, row.names = FALSE, file = file.path(output_dir, "hilfskategorien_kldb_mit_id.csv"), fileEncoding = "UTF-8")

--- a/generate_CSVs.R
+++ b/generate_CSVs.R
@@ -250,52 +250,86 @@ write.csv2(
 
 
 ##############################################
-# write data to excel file, listing all kldb categories (default and folgefrage) and their associated category ids
+# Mapping of all kldb categories (default and folgefrage) to auxco_ids
 # Create file: auxco_mapping_from_kldb.csv
 ##############################################
 
-res <- NULL
+auxco_mapping_from_kldb <- NULL
 for (cat_num in seq_along(ids)) {
-  category_node <- xml_find_all(src, xpath = paste0("//klassifikation/*[", cat_num, "]"))
-  id <- xml_text(xml_find_all(category_node, xpath = "./id"))
-  kldb_id_default <- xml_attr(xml_find_all(category_node, xpath = ".//default/kldb"), "schluessel")
-  kldb_id_folgefrage <- xml_attr(xml_find_all(category_node, xpath = ".//antwort/kldb"), "schluessel")
-  res <- rbind(res, data.table(id, kldb = c(kldb_id_default, kldb_id_folgefrage)))
+  category_node <- src |>
+    xml_find_all(xpath = paste0("//klassifikation/*[", cat_num, "]"))
+  auxco_id <- xml_find_all(category_node, xpath = "./id") |>
+    xml_text()
+  title <- xml_find_all(category_node, xpath = "./bezeichnung") |>
+    xml_text()
+  kldb_id_default <- category_node |>
+    xml_find_all(xpath = ".//default/kldb") |>
+    xml_attr("schluessel")
+  kldb_id_folgefrage <- category_node |>
+    xml_find_all(xpath = ".//antwort/kldb") |>
+    xml_attr("schluessel")
+
+  auxco_mapping_from_kldb <- rbind(
+    auxco_mapping_from_kldb,
+    data.table(
+      auxco_id,
+      kldb_id = c(kldb_id_default, kldb_id_folgefrage),
+      title
+    )
+  )
 }
 
-# nicht alle kldbs stehen in der Hilfsklassifikation, denn einzelne Kategorien in der KldB unterscheiden sich kaum. Für nicht enthaltene KldBs (Spalte kldb) füge Verknüpfungen zu sehr ähnlichen kldbs (Spalte aehnlich_zu) und zu den zugehörigen IDs aus der Hilfsklassifikation (Spalte id) hinzu. Dies ermöglicht Hilfskategorien vorzuschlagen, auch wenn die jeweilige KldB nicht in der Hilfsklassifikation steht.
-res <- rbind(
-  res,
+# TODO: These manual additions should live in the XML or at least a CSV
+
+# nicht alle kldbs stehen in der Hilfsklassifikation, denn einzelne Kategorien
+# in der KldB unterscheiden sich kaum. Für nicht enthaltene KldBs (Spalte kldb)
+# füge Verknüpfungen zu sehr ähnlichen kldbs (Spalte aehnlich_zu) und zu den
+# zugehörigen IDs aus der Hilfsklassifikation (Spalte id) hinzu. Dies ermöglicht
+# Hilfskategorien vorzuschlagen, auch wenn die jeweilige KldB nicht in der
+# Hilfsklassifikation steht.
+manual_mapping_additions <- data.table(
+  auxco_id = c("1014", "1015", "1519", "1518", "5178", "5179", "1716", "1716", "2115", "1733", "1734", "1790", "3205", "3206", "3205", "3206", "3573", "3570", "3550", "3550", "3546", "3542", "7005", "3551", "3552", "3541", "7104", "7043", "7043", "7053", "1828", "1112"),
+  kldb_id = c("11183", "11183", "11402", "11402", "22182", "22182", "22183", "22184", "26382", "26383", "26383", "41383", "71382", "71382", "71383", "71383", "72214", "72214", "73282", "73283", "73284", "73293", "73293", "73293", "73293", "73293", "81382", "81783", "81784", "81784", "82283", "91484")
+)
+# Weitere KldBs stehen nicht mehr in der Hilfsklassifikation (in der
+# Ursprungsversion waren sie noch enthalten), da diese Kategorien sehr allgemein
+# gehalten sind und wir glauben, dass sich Beschäftigte im allgemeinen genauer
+# einordnen können
+manual_mapping_additions <- rbind(
+  manual_mapping_additions,
   data.table(
-    id = c("1014", "1015", "1519", "1518", "5178", "5179", "1716", "1716", "2115", "1733", "1734", "1790", "3205", "3206", "3205", "3206", "3573", "3570", "3550", "3550", "3546", "3542", "7005", "3551", "3552", "3541", "7104", "7043", "7043", "7053", "1828", "1112"),
-    kldb = c("11183", "11183", "11402", "11402", "22182", "22182", "22183", "22184", "26382", "26383", "26383", "41383", "71382", "71382", "71383", "71383", "72214", "72214", "73282", "73283", "73284", "73293", "73293", "73293", "73293", "73293", "81382", "81783", "81784", "81784", "82283", "91484") # ,
-    #                       aehnlich_zu =  c("11103", "11104", "11412", "11422", "22102", "22102", "22103", "22104", "26302", "26303", "26303", "41303", "71302", "71302", "71302", "71302", "72234", "72294", "73202", "73203", "73204", "73214", "73224", "73234", "73244", "73254", "81302", "81713", "81714", "81783", "82233", "91404")
+    auxco_id = c("2093", "2018", "1853", "2022", "2023", "2029", "2034", "1722", "1722", "9041", "9096", "9087", "9063", "9065", "9067", "9069", "9040", "9049", "9076", "9097", "9062", "9064", "9066", "9068", "9070", "9049", "9047", "9076", "4002", "4002", "4002", "4004", "4005", "4006", "4007", "4008", "4210", "4211", "4212", "4213", "4214", "1799", "1785", "6030", "1750", "3205", "3206", "3208", "3210", "3211", "3599", "3531", "3530", "3532", "3533", "3530", "3537", "3599", "5128", "5141"),
+    kldb_id = c("24202", "24202", "24202", "24202", "24202", "24202", "24202", "27103", "27104", "29202", "29202", "29202", "29202", "29202", "29202", "29202", "29202", "29203", "29203", "29203", "29203", "29203", "29203", "29203", "29203", "29204", "29204", "29204", "41203", "41283", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "42283", "42283", "62103", "62103", "71304", "71304", "71304", "71304", "71304", "71304", "73104", "73104", "73104", "73104", "73104", "73104", "73104", "93383", "93383")
   )
 )
-# Weitere KldBs stehen nicht mehr in der Hilfsklassifikation (in der Ursprungsversion waren sie noch enthalten), da diese Kategorien sehr allgemein gehalten sind und wir glauben, dass sich Beschäftigte im allgemeinen genauer einordnen können
-res <- rbind(
-  res,
+# Andere KldBs werden nicht erkannt (siehe Hilfsklassifikation),
+# weil sie abhängig von zwei Folgefragen sind
+manual_mapping_additions <- rbind(
+  manual_mapping_additions,
   data.table(
-    id = c("2093", "2018", "1853", "2022", "2023", "2029", "2034", "1722", "1722", "9041", "9096", "9087", "9063", "9065", "9067", "9069", "9040", "9049", "9076", "9097", "9062", "9064", "9066", "9068", "9070", "9049", "9047", "9076", "4002", "4002", "4002", "4004", "4005", "4006", "4007", "4008", "4210", "4211", "4212", "4213", "4214", "1799", "1785", "6030", "1750", "3205", "3206", "3208", "3210", "3211", "3599", "3531", "3530", "3532", "3533", "3530", "3537", "3599", "5128", "5141"),
-    kldb = c("24202", "24202", "24202", "24202", "24202", "24202", "24202", "27103", "27104", "29202", "29202", "29202", "29202", "29202", "29202", "29202", "29202", "29203", "29203", "29203", "29203", "29203", "29203", "29203", "29203", "29204", "29204", "29204", "41203", "41283", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "41204", "42283", "42283", "62103", "62103", "71304", "71304", "71304", "71304", "71304", "71304", "73104", "73104", "73104", "73104", "73104", "73104", "73104", "93383", "93383") # ,
-    #                       aehnlich_zu =  c("24201", "24203", "24212", "24222", "24232", "24302", "24412", "25103", "25104", "29201", "29212", "29222", "29232", "29242", "29252", "29262", "29282", "29283", "29293", "29213", "29223", "29233", "29243", "29253", "29263", "29283", "29284", "29294", "41213", "41213", "41214", "41234", "41244", "41254", "41264", "41274", "41284", "41284", "41284", "41284", "41284", "42203", "34313", "62102", "62193", "71303", "71303", "71314", "71394", "71394", "71594", "73124", "73134", "73144", "73154", "73183", "73194", "71394", "93303", "93393")
-  )
-)
-# Andere KldBs werden nicht erkannt (siehe Hilfsklassifikation), weil sie abhängig von zwei Folgefragen sind
-res <- rbind(
-  res,
-  data.table(
-    id = c("1748", "1749", "1748", "1749"),
-    kldb = c("61204", "61214", "61284", "61284")
+    auxco_id = c("1748", "1749", "1748", "1749"),
+    kldb_id = c("61204", "61214", "61284", "61284")
   )
 )
 
+# Add title information and then combine the manual mapping
+# with the existing auxco mapping
+manual_mapping_additions <- merge(
+  manual_mapping_additions,
+  auxco_mapping_from_kldb[, list(auxco_id, title)],
+  by = "auxco_id"
+)
+auxco_mapping_from_kldb <- rbind(
+  auxco_mapping_from_kldb,
+  manual_mapping_additions
+)
 
-res <- unique(res)
+# TODO: Add kldb_title via join
 
-map_kldb_to_auxcoid <- res
+auxco_mapping_from_kldb <- unique(auxco_mapping_from_kldb)
+
 write.csv2(
-  res,
+  auxco_mapping_from_kldb,
   row.names = FALSE,
   file = file.path(output_dir, "auxco_mapping_from_kldb.csv"),
   fileEncoding = "UTF-8"

--- a/generate_CSVs.R
+++ b/generate_CSVs.R
@@ -25,7 +25,7 @@ library(data.table)
 library(stringdist)
 
 # read auxiliary classification
-src <- read_xml("https://raw.githubusercontent.com/malsch/occupationCodingAuxco/master/hilfsklassifikation.xml")
+src <- read_xml("./hilfsklassifikation.xml")
 
 # remove all answer options that ask for an open-ended answer
 # Not yet implemented, but it may be worth to look at this again.

--- a/generate_CSVs.R
+++ b/generate_CSVs.R
@@ -2,22 +2,22 @@
 # Der folgende Code lädt die Datei hilfsklassifikation.xml.
 #
 # Daraus werden im nachfolgenden Code die folgenden Dateien erstellt:
-# - hilfskategorien_sortiert_nach_id.csv
-# - abgrenzungen_sortiert_nach_kldb.csv
-# - folgefragen.csv
-# - hilfskategorien_kldb_mit_id.csv
+# - auxco_categories.csv
+# - auxco_distinctions.csv
+# - auxco_followup_questions.csv
+# - auxco_mapping_from_kldb.csv
 # Sie stellen ausgewählte Inhalte übersichtlicher dar.
 #
-# hilfskategorien_sortiert_nach_id.csv enthält zu jeder Hilfskategorie die ID, die Bezeichnung, die Tätigkeit, die Tätigkeitsbeschreibung sowie zugeordnete Berufskategorien aus der KldB 2010 sowie aus ISCO-08.
-# abgrenzungen_sortiert_nach_kldb.csv enthält die Abgrenzungen von allen Hilfskategorien. Zu jeder ID sind alle Abgrenzungen (REFID) und ihr jeweiliger TYP einzeln angegeben.
-# folgefragen.csv enthält sämtliche Folgefragen. Dargestellt sind die Fragetexte, die einzelnen Antwortoptionen sowie die ihnen zugeordneten Berufskategorien aus der KldB 2010 und aus ISCO-08.
-# hilfskategorien_kldb_mit_id.csv enthält zu jeder Hilfskategorie die zugeordneten KldB-Kategorien (Default-Kategorie und Kategorie aus Folgefrage). Und selbst für nicht in der Hilfsklassifikation enthaltene KldBs werden dort passende IDs aus der Hilfsklassifikation benannt.
+# auxco_categories.csv enthält zu jeder Hilfskategorie die ID, die Bezeichnung, die Tätigkeit, die Tätigkeitsbeschreibung sowie zugeordnete Berufskategorien aus der KldB 2010 sowie aus ISCO-08.
+# auxco_distinctions.csv enthält die Abgrenzungen von allen Hilfskategorien. Zu jeder ID sind alle Abgrenzungen (REFID) und ihr jeweiliger TYP einzeln angegeben.
+# auxco_followup_questions.csv enthält sämtliche Folgefragen. Dargestellt sind die Fragetexte, die einzelnen Antwortoptionen sowie die ihnen zugeordneten Berufskategorien aus der KldB 2010 und aus ISCO-08.
+# auxco_mapping_from_kldb.csv enthält zu jeder Hilfskategorie die zugeordneten KldB-Kategorien (Default-Kategorie und Kategorie aus Folgefrage). Und selbst für nicht in der Hilfsklassifikation enthaltene KldBs werden dort passende IDs aus der Hilfsklassifikation benannt.
 #
 # Eine weitere Datei vergleich_hilfsklassifikation_berufenet.csv ist nur unter https://www.iab.de/183/section.aspx/Publikation/k180509301 verlinkt. Dort werden die Hilfskategorien der Hilfskategorien mit den Berufsbezeichnungen aus dem BERUFENET verglichen.
 #
 # Malte Schierholz
 # 23. Februar 2018 (Ursprungsversion von https://www.iab.de/183/section.aspx/Publikation/k180509301)
-# 10. Februar 2019 (Anpassung für Github, Berücksichtigung der Folgefragen-Syntax vom 7.2.2019, hilfskategorien_kldb_mit_id.csv hinzugefügt)
+# 10. Februar 2019 (Anpassung für Github, Berücksichtigung der Folgefragen-Syntax vom 7.2.2019, auxco_mapping_from_kldb.csv hinzugefügt)
 ####################################################################################
 
 library(xml2)
@@ -42,7 +42,7 @@ ids <- as.numeric(xml_text(xml_find_all(src, xpath = "//id")))
 ##############################################
 ### Write data to excel file, listing all auxiliary categories order by id
 ### Every category from the auxiliary classification must appear exactly once
-### Create file: hilfskategorien_sortiert_nach_id.csv
+### Create file: auxco_categories.csv
 ##############################################
 
 res <- NULL
@@ -61,11 +61,11 @@ for (cat_num in seq_along(ids)) {
 
 
 hilfskategorien <- res[order(id)]
-write.csv2(res[order(id)], row.names = FALSE, file = file.path(output_dir, "hilfskategorien_sortiert_nach_id.csv"), fileEncoding = "UTF-8")
+write.csv2(res[order(id)], row.names = FALSE, file = file.path(output_dir, "auxco_categories.csv"), fileEncoding = "UTF-8")
 
 ###############################################
 ### Write data to excel file, listing all abgrenzungen
-### Create file: abgrenzungen_sortiert_nach_kldb.csv
+### Create file: auxco_distinctions.csv
 ###############################################
 
 res <- NULL
@@ -82,11 +82,11 @@ for (cat_num in seq_along(ids)) {
 }
 
 abgrenzungen <- res[order(kldb_id_default)]
-write.csv2(res[order(kldb_id_default)], row.names = FALSE, file = file.path(output_dir, "abgrenzungen_sortiert_nach_kldb.csv"), fileEncoding = "UTF-8")
+write.csv2(res[order(kldb_id_default)], row.names = FALSE, file = file.path(output_dir, "auxco_distinctions.csv"), fileEncoding = "UTF-8")
 
 ###############################################
 ### Write data to excel file, listing all Folgefragen
-### Create file: folgefragen.csv
+### Create file: auxco_followup_questions.csv
 ###############################################
 
 res <- NULL
@@ -122,12 +122,12 @@ res <- res[order(id)]
 res[, laufindexFolge := 1:.N]
 
 folgefragen <- res[, list(laufindexFolge, id, questionNumber, typ, fragetextAktuellerBeruf, fragetextVergangenerBeruf, antwort.pos, antwort.text, antwort.kldb, antwort.isco, followUp)]
-write.csv2(res[, list(laufindexFolge, id, questionNumber, typ, fragetextAktuellerBeruf, fragetextVergangenerBeruf, antwort.pos, antwort.text, antwort.kldb, antwort.isco, followUp)], row.names = FALSE, file = file.path(output_dir, "folgefragen.csv"), fileEncoding = "UTF-8")
+write.csv2(res[, list(laufindexFolge, id, questionNumber, typ, fragetextAktuellerBeruf, fragetextVergangenerBeruf, antwort.pos, antwort.text, antwort.kldb, antwort.isco, followUp)], row.names = FALSE, file = file.path(output_dir, "auxco_followup_questions.csv"), fileEncoding = "UTF-8")
 
 
 ##############################################
 # write data to excel file, listing all kldb categories (default and folgefrage) and their associated category ids
-# Create file: hilfskategorien_kldb_mit_id.csv
+# Create file: auxco_mapping_from_kldb.csv
 ##############################################
 
 res <- NULL
@@ -170,4 +170,4 @@ res <- rbind(
 res <- unique(res)
 
 map_kldb_to_auxcoid <- res
-write.csv2(res, row.names = FALSE, file = file.path(output_dir, "hilfskategorien_kldb_mit_id.csv"), fileEncoding = "UTF-8")
+write.csv2(res, row.names = FALSE, file = file.path(output_dir, "auxco_mapping_from_kldb.csv"), fileEncoding = "UTF-8")

--- a/generate_CSVs.R
+++ b/generate_CSVs.R
@@ -85,11 +85,10 @@ for (cat_num in seq_along(ids)) {
 # Order by id
 auxco_categories <- auxco_categories[order(auxco_id)]
 
-write.csv2(
+fwrite(
   auxco_categories,
   row.names = FALSE,
-  file = file.path(output_dir, "auxco_categories.csv"),
-  fileEncoding = "UTF-8"
+  file = file.path(output_dir, "auxco_categories.csv")
 )
 
 ###############################################
@@ -130,11 +129,10 @@ for (cat_num in seq_along(ids)) {
 # next to each other
 auxco_distinctions <- auxco_distinctions[order(default_kldb_id)]
 
-write.csv2(
+fwrite(
   auxco_distinctions,
   row.names = FALSE,
-  file = file.path(output_dir, "auxco_distinctions.csv"),
-  fileEncoding = "UTF-8"
+  file = file.path(output_dir, "auxco_distinctions.csv")
 )
 
 ###############################################
@@ -241,11 +239,10 @@ auxco_followup_questions[
 ]
 auxco_followup_questions[, explicit_has_followup := NULL]
 
-write.csv2(
+fwrite(
   auxco_followup_questions,
   row.names = FALSE,
-  file = file.path(output_dir, "auxco_followup_questions.csv"),
-  fileEncoding = "UTF-8"
+  file = file.path(output_dir, "auxco_followup_questions.csv")
 )
 
 
@@ -328,9 +325,8 @@ auxco_mapping_from_kldb <- rbind(
 
 auxco_mapping_from_kldb <- unique(auxco_mapping_from_kldb)
 
-write.csv2(
+fwrite(
   auxco_mapping_from_kldb,
   row.names = FALSE,
-  file = file.path(output_dir, "auxco_mapping_from_kldb.csv"),
-  fileEncoding = "UTF-8"
+  file = file.path(output_dir, "auxco_mapping_from_kldb.csv")
 )

--- a/generate_CSVs.R
+++ b/generate_CSVs.R
@@ -271,10 +271,10 @@ for (cat_num in seq_along(ids)) {
     data.table(
       auxco_id,
       title,
-      default_kldb_id,
-      default_isco_id,
       task,
-      task_description
+      task_description,
+      default_kldb_id,
+      default_isco_id
     )
   )
 }

--- a/generate_CSVs.R
+++ b/generate_CSVs.R
@@ -48,37 +48,45 @@ ids <- as.numeric(xml_text(xml_find_all(src, xpath = "//id")))
 ### Create file: auxco_categories.csv
 ##############################################
 
-res <- NULL
+auxco_categories <- NULL
 for (cat_num in seq_along(ids)) {
-  category_node <- xml_find_all(src, xpath = paste0("//klassifikation/*[", cat_num, "]"))
-  id <- xml_text(xml_find_all(category_node, xpath = "./id"))
-  taetigkeit <- xml_text(xml_find_all(category_node, xpath = "./taetigkeit"))
-  taetigkeitsbeschreibung <- xml_text(xml_find_all(category_node, xpath = "./taetigkeitsbeschreibung"))
-  bezeichnung <- xml_text(xml_find_all(category_node, xpath = "./bezeichnung"))
-  kldb_id_default <- xml_attr(xml_find_all(category_node, xpath = ".//default/kldb"), "schluessel")
-  isco_id_default <- xml_attr(xml_find_all(category_node, xpath = ".//default/isco"), "schluessel")
-  kldb_id_folgefrage <- xml_attr(xml_find_all(category_node, xpath = ".//antwort/kldb"), "schluessel")
-  isco_id_folgefrage <- xml_attr(xml_find_all(category_node, xpath = ".//antwort/isco"), "schluessel")
-  res <- rbind(
-    res,
+  category_node <- xml_find_all(
+    src,
+    xpath = paste0("//klassifikation/*[", cat_num, "]")
+  )
+  auxco_id <- xml_find_all(category_node, xpath = "./id") |>
+    xml_text()
+  title <- xml_find_all(category_node, xpath = "./bezeichnung") |>
+    xml_text()
+  task <- xml_find_all(category_node, xpath = "./taetigkeit") |>
+    xml_text()
+  task_description <- xml_find_all(
+    category_node,
+    xpath = "./taetigkeitsbeschreibung"
+  ) |>
+    xml_text()
+  default_kldb <- xml_find_all(category_node, xpath = ".//default/kldb") |>
+    xml_attr("schluessel")
+  default_isco <- xml_find_all(category_node, xpath = ".//default/isco") |>
+    xml_attr("schluessel")
+  auxco_categories <- rbind(
+    auxco_categories,
     data.table(
-      id,
-      bezeichnung,
-      kldb_default = kldb_id_default,
-      kldb_folgefrage = paste(kldb_id_folgefrage, collapse = ", "),
-      isco_default = isco_id_default,
-      isco_folgefrage = paste(isco_id_folgefrage,
-        collapse = ", "
-      ),
-      taetigkeit, taetigkeitsbeschreibung
+      auxco_id,
+      title,
+      default_kldb,
+      default_isco,
+      task,
+      task_description
     )
   )
 }
 
+# Order by id
+auxco_categories <- auxco_categories[order(auxco_id)]
 
-hilfskategorien <- res[order(id)]
 write.csv2(
-  res[order(id)],
+  auxco_categories,
   row.names = FALSE,
   file = file.path(output_dir, "auxco_categories.csv"),
   fileEncoding = "UTF-8"


### PR DESCRIPTION
This PR updates the format in which CSVs are generated from the underlying XML file. The data itself remains largely unchanged with mainly the filenames and column names changing as well as the underlying code used to generate them. 

The only major change to data itself,is the merge of kldb-level 4 titles as additional titles within `auxco_categories.csv`. This code is moved from another R package into this one.